### PR TITLE
Yelee不能生成页面，yelee才行

### DIFF
--- a/1.Getting-Started/installation.md
+++ b/1.Getting-Started/installation.md
@@ -15,7 +15,7 @@ git clone https://github.com/MOxFIVE/hexo-theme-yelee.git themes/yelee
 再修改 Hexo 根目录对应配置文件 `_config.yml`，即可切换到 Yelee 主题
 
 ```yaml
-theme: Yelee
+theme: yelee
 ```
 
 ![安装说明1](/src/installation-1.png)


### PR DESCRIPTION
git clone https://github.com/MOxFIVE/hexo-theme-yelee.git themes/yelee 克隆之后生成的是yelee目录，yaml文件中应该填入相应的字符。图片也最好生成小写的，我刚开始用就被误导了~